### PR TITLE
Fix typo in vignette

### DIFF
--- a/vignettes/vignette.Rmd
+++ b/vignettes/vignette.Rmd
@@ -328,7 +328,7 @@ We then select genes that differential expressed genes within cluster `C3` (Epit
 ```{r}
 load(gzcon(url('https://xuranw.github.io/MuSiC/data//IEmarkers.RData')))
 
-Est.mouse.bulk = music_prop.cluster(bulk.eset = Mouse.bulk.eset, sc.eset = Mousesub.eset, group.markers = IEmarkers, clusters = 'cellType', group = 'clusterType', samples = 'sampleID', clusters.type = clusters.type)
+Est.mouse.bulk = music_prop.cluster(bulk.eset = Mouse.bulk.eset, sc.eset = Mousesub.eset, group.markers = IEmarkers, clusters = 'cellType', groups = 'clusterType', samples = 'sampleID', clusters.type = clusters.type)
 ```
 
 


### PR DESCRIPTION
Using just `group` will match multiple arguments and thus fail.