### PR TITLE
Prop_comp_multi/Abs_diff_multi: Fix text annotation

### DIFF
--- a/R/plot.R
+++ b/R/plot.R
@@ -182,14 +182,15 @@ Abs_diff_multi = function(prop.real, prop.est, method.name = NULL, title = NULL,
     m.prop.real = data.frame(Prop = c(cm.prop.real), CellType = factor(rep(celltype, each = N), levels = celltype),
                              Sub = factor(rep(sub,K), levels = sub), Method = rep('Real', N*K) )
 
-    abs.diff = NULL; ann = NULL;
+    abs.diff = NULL
+    ann <- data.frame(metric = character(0), Method = character(0))
     for(l in 1:L){
       abs.diff.temp = m.prop.real; colnames(abs.diff.temp)[1] = 'Abs.Diff';
       cm.prop.est = prop.est[[l]][match(sub, l.sub.est[[l]]), match(celltype, l.ct.est[[l]])]
       abs.diff.temp$Abs.Diff = abs( c( cm.prop.est ) - m.prop.real$Prop)
       abs.diff.temp$Method = factor(rep(method.name[l], K*N), levels = method.name);
-      ann = c(ann, paste0('RMSD = ', round( sqrt(mean((cm.prop.real-cm.prop.est)^2)), digits = 5 ),
-                          '\n mAD = ', round( mean( abs.diff.temp$Abs.Diff), digits = 5 )) )
+      ann <- rbind(ann, data.frame(metric = paste0("RMSD = ", round(sqrt(mean((cm.prop.real - cm.prop.est)^2)), digits = 5), "\n mAD = ",
+                                                   round(mean(abs.diff.temp$Abs.Diff), digits = 5)), Method = method.name[l]))
       abs.diff = rbind(abs.diff, abs.diff.temp)
     }
   }else{
@@ -218,7 +219,8 @@ Abs_diff_multi = function(prop.real, prop.est, method.name = NULL, title = NULL,
     ggplot(abs.diff, aes(CellType, Sub)) + geom_tile(aes(fill = Abs.Diff), colour = 'white')+ scale_fill_gradient(
       low = 'white', high = 'steelblue', name = 'Abs.Diff\n') + facet_wrap( ~ Method, nrow = 1) + theme(
         axis.text.x = element_text(angle = -90, size = 10, vjust = 0) ) + #geom_text(aes(label = round(Abs.Diff, 2))) +
-      ggtitle(title) + annotate("text", label = ann, x = round(4*K/5), y = N-0.5, size = 2.5, colour = "black")
+      ggtitle(title) +
+      geom_text(data = ann, aes(x = round(4 * K / 5), y = N - 0.5, label = metric), size = 2.5, colour = "black")
   }else{
     ggplot(abs.diff, aes(CellType, Sub)) + geom_tile(aes(fill = Abs.Diff), colour = 'white')+ scale_fill_gradient(
       low = 'white', high = 'steelblue', name = 'Abs.Diff\n') + facet_wrap( ~ Method, nrow = 1) + theme(

--- a/R/plot.R
+++ b/R/plot.R
@@ -107,13 +107,15 @@ Prop_comp_multi = function(prop.real, prop.est, method.name = NULL, title = NULL
   cm.prop.real = prop.real[match(sub, sub.real), match(celltype, ct.real)]
   m.prop.real = data.frame(Prop = c(cm.prop.real), CellType = factor(rep(celltype, each = N), levels = celltype),
                            Sub = factor(rep(sub,K), levels = sub), Method = rep('Real', N*K) )
-  m.prop.est = NULL; ann = '';
+  m.prop.est = NULL;
+  ann = data.frame(metric='',Method='Real')
   for(l in 1:L){
     m.prop.temp = m.prop.real
     cm.prop.est = prop.est[[l]][match(sub, l.sub.est[[l]]), match(celltype, l.ct.est[[l]])]
     m.prop.temp$Prop = c( cm.prop.est )
     m.prop.temp$Method = factor(rep(method.name[l], K*N), levels = method.name);
-    ann = c(ann, paste0('R = ', round(cor(c(cm.prop.real), c(cm.prop.est)), digits = 4)))
+    # ann = c(ann, paste0('R = ', round(cor(c(cm.prop.real), c(cm.prop.est)), digits = 4)))
+    ann <- rbind(ann,data.frame(metric=paste0('R = ', round(cor(c(cm.prop.real), c(cm.prop.est)), digits = 4)),Method=method.name[l]))
     m.prop.est = rbind(m.prop.est, m.prop.temp)
   }
   m.prop = rbind(m.prop.real, m.prop.est);
@@ -123,7 +125,7 @@ Prop_comp_multi = function(prop.real, prop.est, method.name = NULL, title = NULL
   if(eval){
     ggplot(m.prop, aes(CellType, Sub)) + geom_tile(aes(fill = Prop), colour = 'white') + scale_fill_gradient2(
       low = 'steelblue', high = "red", mid = 'white', midpoint = 0.5, limit = c(0, 1), name = 'Est Prop\n')  + facet_wrap(~Method, nrow = 1) + theme(
-        axis.text.x = element_text(angle = -90, size = 10, vjust = 0) ) + ggtitle(title) + annotate("text", label = ann, x = round(4*K/5), y = N, size = 2.5, colour = "black")
+        axis.text.x = element_text(angle = -90, size = 10, vjust = 0) ) + ggtitle(title) + geom_text(data = ann,aes(x = round(4*K/5), y = N,label=metric),  size = 2.5, colour = "black")
   }else{
     ggplot(m.prop, aes(CellType, Sub)) + geom_tile(aes(fill = Prop), colour = 'white') + scale_fill_gradient2(
       low = 'steelblue', high = "red", mid = 'white', midpoint = 0.5, limit = c(0, 1), name = 'Est Prop\n')  + facet_wrap(~Method, nrow = 1) + theme(


### PR DESCRIPTION
Without these fixes, `Prop_comp_multi` and `Abs_diff_multi` throw the following error:

> ```
> Error: Aesthetics must be either length 1 or the same as the data (9): `label`
> ```

(see issue #52).

The solution for `Prop_comp_multi` (see 0da621caf044b10fc2b53538261ea3ade4c37984) was suggested by @mxcai [here](https://github.com/xuranw/MuSiC/issues/52#issuecomment-722070234).
The adjustments to `Abs_diff_multi` (see e4f72c96bbff1fb2d9c67153c4084698e45c538b) were added by me but are conceptually based on @mxcai's work.